### PR TITLE
fix: Fix error when `.env` already exists while `yarn install`

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.0",
     "private": true,
     "scripts": {
-        "preinstall": "cp -n .env.example .env",
+        "preinstall": "test -f .env || cp -n .env.example .env",
         "postinstall": "husky install",
         "start": "react-scripts start",
         "build": "react-scripts build",


### PR DESCRIPTION
Known it occurs on MacOS, Linux is fine, Windows unknown